### PR TITLE
remove redundant rm alias

### DIFF
--- a/.config/zsh/rc/alias.zsh
+++ b/.config/zsh/rc/alias.zsh
@@ -4,8 +4,6 @@
 #==============================================================#
 
 ## common ##
-alias rm='rm-trash'
-alias del='rm -rf'
 alias cp='cp -irf'
 alias mv='mv -i'
 alias ..='cd ..'


### PR DESCRIPTION
the valid `alias rm` is `trash put ` in pluginlist.zsh
<img width="299" alt="image" src="https://github.com/yutkat/dotfiles/assets/73770413/c03ca366-fbaa-4209-9347-af596d666c5d">
`alias rm='rm-trash'` leads to the failure of del
<img width="678" alt="image" src="https://github.com/yutkat/dotfiles/assets/73770413/11129218-fa87-4992-8249-9390bb76db5d">
